### PR TITLE
install copt through pip rather than github

### DIFF
--- a/solvers/copt.py
+++ b/solvers/copt.py
@@ -13,7 +13,7 @@ class Solver(BaseSolver):
     name = 'copt'
 
     install_cmd = 'conda'
-    requirements = ['pip:https://github.com/openopt/copt/archive/master.zip']
+    requirements = ['pip:copt']
 
     parameters = {
         'accelerated': [False, True],


### PR DESCRIPTION
For me it's more stable to install package through pip when they are available on PyPI. At least this works on my machine while the version on main fails.
@tomMoral 