### PR TITLE
Add Cuml solver

### DIFF
--- a/solvers/cuml.py
+++ b/solvers/cuml.py
@@ -29,8 +29,8 @@ class Solver(BaseSolver):
 
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
-        self.X = cudf.DataFrame(self.X.astype(np.float64))
-        self.y = cudf.Series((self.y > 0).astype(np.float64))
+        self.X = cudf.DataFrame(self.X.astype(np.float32))
+        self.y = cudf.Series((self.y > 0).astype(np.float32))
 
         self.clf = LogisticRegression(
             fit_intercept=False,

--- a/solvers/cuml.py
+++ b/solvers/cuml.py
@@ -1,0 +1,49 @@
+from benchopt import BaseSolver, safe_import_context
+from benchopt.utils.sys_info import _get_cuda_version
+
+with safe_import_context() as import_ctx:
+    import cudf
+    import numpy as np
+    from cuml.linear_model import LogisticRegression
+
+
+class Solver(BaseSolver):
+    name = "cuml"
+
+    cuda_version = _get_cuda_version()
+    if cuda_version is not None:
+        install_cmd = "conda"
+        cuda_version = cuda_version.split("cuda_", 1)[1][:4]
+        requirements = [
+            "rapidsai::rapids",
+            f"nvidia::cudatoolkit={cuda_version}",
+            "dask-sql",
+        ]
+
+    parameters = {
+        "solver": [
+            "qn",
+        ],
+    }
+    parameter_template = "{solver}"
+
+    def set_objective(self, X, y, lmbd):
+        self.X, self.y, self.lmbd = X, y, lmbd
+        self.X = cudf.DataFrame(self.X.astype(np.float64))
+        self.y = cudf.Series((self.y > 0).astype(np.float64))
+
+        self.clf = LogisticRegression(
+            fit_intercept=False,
+            C=1 / self.lmbd,
+            penalty="l2",
+            tol=1e-15,
+            solver=self.solver,
+            verbose=0,
+        )
+
+    def run(self, n_iter):
+        self.clf.solver_model.max_iter = n_iter
+        self.clf.fit(self.X, self.y)
+
+    def get_result(self):
+        return self.clf.coef_.to_numpy().flatten()

--- a/solvers/cuml.py
+++ b/solvers/cuml.py
@@ -1,7 +1,14 @@
 from benchopt import BaseSolver, safe_import_context
 from benchopt.utils.sys_info import _get_cuda_version
 
+cuda_version = _get_cuda_version()
+if cuda_version is not None:
+    cuda_version = cuda_version.split("cuda_", 1)[1][:4]
+
 with safe_import_context() as import_ctx:
+    if cuda_version is None:
+        raise ImportError("cuml solver needs a nvidia GPU.")
+
     import cudf
     import numpy as np
     from cuml.linear_model import LogisticRegression
@@ -10,15 +17,12 @@ with safe_import_context() as import_ctx:
 class Solver(BaseSolver):
     name = "cuml"
 
-    cuda_version = _get_cuda_version()
-    if cuda_version is not None:
-        install_cmd = "conda"
-        cuda_version = cuda_version.split("cuda_", 1)[1][:4]
-        requirements = [
-            "rapidsai::rapids",
-            f"nvidia::cudatoolkit={cuda_version}",
-            "dask-sql",
-        ]
+    install_cmd = "conda"
+    requirements = [
+        "rapidsai::rapids",
+        f"nvidia::cudatoolkit={cuda_version}",
+        "dask-sql",
+    ] if cuda_version is not None else []
 
     parameters = {
         "solver": [

--- a/test_config.py
+++ b/test_config.py
@@ -10,4 +10,5 @@ def check_test_solver_install(solver_class):
     particular architecture, call pytest.xfail when
     detecting the situation.
     """
-    pass
+    if solver_class.name.lower() == "cuml" and sys.platform == "darwin":
+        pytest.xfail("Cuml is not supported on MacOS.")

--- a/test_config.py
+++ b/test_config.py
@@ -1,5 +1,5 @@
 import sys  # noqa: F401
-
+from benchopt.utils.sys_info import _get_cuda_version
 import pytest  # noqa: F401
 
 
@@ -10,5 +10,9 @@ def check_test_solver_install(solver_class):
     particular architecture, call pytest.xfail when
     detecting the situation.
     """
-    if solver_class.name.lower() == "cuml" and sys.platform == "darwin":
-        pytest.xfail("Cuml is not supported on MacOS.")
+    if solver_class.name.lower() == "cuml":
+        if sys.platform == "darwin":
+            pytest.xfail("Cuml is not supported on MacOS.")
+        cuda_version = _get_cuda_version()
+        if cuda_version is None:
+            pytest.xfail("Cuml needs a working GPU hardware.")


### PR DESCRIPTION
Fixes #23 by adding cuml solver
Cuml is not supported under MacOs.
The CI is expected to turn red as github CI does not have a GPU to test with. And also there is no "cpu" alternative like there usually is (they refer to scikit learn methods in their doc if we want to run on cpu).