### PR TITLE
Do not skip SGD solver for small datasets

### DIFF
--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -29,11 +29,6 @@ class Solver(BaseSolver):
     }
     parameter_template = "{solver}"
 
-    def skip(self, X, y, lmbd):
-        if self.solver in ["sgd", "sag", "saga"] and X.shape[0] < 1000:
-            return True, f"Not enough samples for {self.solver.upper()}"
-        return False, None
-
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 


### PR DESCRIPTION
Similarly to the SGD solver, the SAG and SAGA solvers work best when the number of samples is large.

I propose to skip these two solvers for small datasets.
___
Example on `Simulated[n_samples=200, n_features=500]`:
![image](https://user-images.githubusercontent.com/11065596/160957111-011f380f-21f2-4248-84a5-1697ae42d4ae.png)