### PR TITLE
[WIP] Mini-batch SAGA solver from StochOpt.jl

### DIFF
--- a/solvers/julia_saga_batch.jl
+++ b/solvers/julia_saga_batch.jl
@@ -1,0 +1,3 @@
+using StochOpt
+
+# do something here

--- a/solvers/julia_saga_batch.py
+++ b/solvers/julia_saga_batch.py
@@ -1,0 +1,49 @@
+from benchopt import safe_import_context
+
+from benchopt.helpers.julia import JuliaSolver
+from benchopt.helpers.julia import get_jl_interpreter
+from benchopt.helpers.julia import assert_julia_installed
+
+with safe_import_context() as import_ctx:
+    assert_julia_installed()
+
+
+# File containing the function to be called from julia
+JULIA_SOLVER_FILE = str('julia_saga_batch.jl')
+
+
+class Solver(JuliaSolver):
+
+    name = 'Julia-SAGA-Batch'
+    references = [
+        'Gazagnadou, Nidham, Robert Gower, and Joseph Salmon,'
+        ' "Optimal mini-batch and step sizes for SAGA." '
+        'International conference on machine learning. PMLR, 2019.'
+        'https://github.com/gowerrobert/StochOpt.jl'
+    ]
+
+    def set_requirements(self):
+        # List of dependencies can be found on the package github
+        self.julia_requirements = [
+            'https://github.com/tbng/StochOpt.jl',
+        ]
+
+    def skip(self, X, y, lmbd, fit_intercept):
+        # fit intercept is not yet implemented in StochOpt.jl
+        if fit_intercept:
+            return True, f"{self.name} does not handle fit_intercept"
+
+        return False, None
+
+    def set_objective(self, X, y, lmbd, fit_intercept):
+        self.X, self.y, self.lmbd = X, y, lmbd
+        self.fit_intercept = fit_intercept
+
+        jl = get_jl_interpreter()
+        self.solve_logreg_l2 = jl.include(JULIA_SOLVER_FILE)
+
+    def run(self, n_iter):
+        self.beta = self.solve_lasso(self.X, self.y, self.lmbd, n_iter)
+
+    def get_result(self):
+        return self.beta.ravel()


### PR DESCRIPTION
Objective: adding solver implemented in julia from https://github.com/gowerrobert/StochOpt.jl  . Based on [Nidham Gazagnadou, Robert M. Gower, Joseph Salmon (2019). Optimal mini-batch and step sizes for SAGA](https://arxiv.org/abs/1902.00071).

TODO list:

- [ ] Write a julia solver that calls and returns the fitted weights (`solvers/julia_saga_batch.jl`)
- [ ] Write a python wrapper for the file, including installing the required packages, then run the wrapper function (` solvers/julia_saga_batch.py`)
- [ ] Benchmarks this solver with multiple other solvers (sklearn l-bfgs + SGD + SAGA, SVRG, etc.) with different datasets from libsvm) 

Right now I am stuck at the step to add requirements for the julia solver to compile from the fork of StochOpt https://github.com/tbng/StochOpt.jl , the difference of this fork from original repo is:

1.  Adding `Project.toml` file to have proper setup and compile the package
2. Remove heavy datasets which are not required for the cloning + setup process with benchopt ;

however the package failed to compile if one enter the julia Pkg CLI and try 
```julia
(bnguyen) pkg> add https://github.com/tbng/StochOpt.jl

add https://github.com/tbng/StochOpt.jl
```
```julia
Precompiling project...
  ✗ StochOpt
  0 dependencies successfully precompiled in 2 seconds (145 already precompiled)
  1 dependency errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the package
```
```julia
julia> import Pkg; Pkg.precompile()
Precompiling project...
  ✗ StochOpt
  0 dependencies successfully precompiled in 2 seconds (145 already precompiled)

ERROR: The following 1 direct dependency failed to precompile:

StochOpt [a296cd5f-c7bb-434a-b235-e4cfe6c2e67a]

Failed to precompile StochOpt [a296cd5f-c7bb-434a-b235-e4cfe6c2e67a] to /home/bnguyen/miniconda3/envs/phd/share/julia/compiled/v1.7/StochOpt/jl_Y2jNgY.
┌ Warning: Package Base does not have LinearAlgebra in its dependencies:
│ - If you have Base checked out for development and have
│   added LinearAlgebra as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Base
└ Loading LinearAlgebra into Base from project dependency, future warnings for Base are suppressed.
ERROR: LoadError: UndefVarError: include not defined
Stacktrace:
 [1] top-level scope
   @ ~/miniconda3/envs/phd/share/julia/packages/StochOpt/Jmb8W/src/StochOpt.jl:377
 [2] include
   @ ./Base.jl:418 [inlined]
 [3] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
   @ Base ./loading.jl:1318
 [4] top-level scope
   @ none:1
 [5] eval
   @ ./boot.jl:373 [inlined]
 [6] eval(x::Expr)
   @ Base.MainInclude ./client.jl:453
 [7] top-level scope
   @ none:1
in expression starting at /home/bnguyen/miniconda3/envs/phd/share/julia/packages/StochOpt/Jmb8W/src/StochOpt.jl:377
Stacktrace:
 [1] pkgerror(msg::String)
   @ Pkg.Types ~/miniconda3/envs/phd/share/julia/stdlib/v1.7/Pkg/src/Types.jl:68
 [2] precompile(ctx::Pkg.Types.Context; internal_call::Bool, strict::Bool, warn_loaded::Bool, already_instantiated::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Pkg.API ~/miniconda3/envs/phd/share/julia/stdlib/v1.7/Pkg/src/API.jl:1362
 [3] precompile
   @ ~/miniconda3/envs/phd/share/julia/stdlib/v1.7/Pkg/src/API.jl:1013 [inlined]
 [4] #precompile#220
   @ ~/miniconda3/envs/phd/share/julia/stdlib/v1.7/Pkg/src/API.jl:1011 [inlined]
 [5] precompile()
   @ Pkg.API ~/miniconda3/envs/phd/share/julia/stdlib/v1.7/Pkg/src/API.jl:1011
 [6] top-level scope
   @ REPL[4]:1

```

Since I have almost zero experience coding in julia, it would be great to have some help. As discussed with @tomMoral I think the `.toml` file added in my fork is not properly done.