### PR TITLE
FIX logloss name in sklearn

### DIFF
--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -39,7 +39,7 @@ class Solver(BaseSolver):
 
         if self.solver == 'sgd':
             self.clf = SGDClassifier(
-                loss="log", alpha=self.lmbd / (X.shape[0] * 2.0),
+                loss="log_loss", alpha=self.lmbd / (X.shape[0] * 2.0),
                 penalty='l2', fit_intercept=False, tol=1e-15,
                 random_state=42, eta0=.01, learning_rate="constant"
             )


### PR DESCRIPTION
Fixed the name of the loss of the SGDClassifier in solvers/sklearn.py due to the following error:

The 'loss' parameter of SGDClassifier must be a str among {'hinge', 'perceptron', 'log_loss', 'squared_hinge', 'huber', 'modified_huber', 'squared_error', 'epsilon_insensitive', 'squared_epsilon_insensitive'}. Got 'log' instead.
