### PR TITLE
FIX avoid bad condition number in covtype dataset

### DIFF
--- a/datasets/covtype.py
+++ b/datasets/covtype.py
@@ -3,6 +3,7 @@ from benchopt import BaseDataset, safe_import_context
 
 with safe_import_context() as import_ctx:
     from sklearn.datasets import fetch_covtype
+    from sklearn.preprocessing import StandardScaler
 
 
 class Dataset(BaseDataset):
@@ -15,4 +16,10 @@ class Dataset(BaseDataset):
         X, y = fetch_covtype(return_X_y=True)
         y[y != 2] = -1
         y[y == 2] = 1  # try to separate class 2 from the other 6 classes.
+
+        # This dataset contains a mixture of numeric columns and
+        # one-hot-encoded categorical columns, scale it to avoid very large
+        # condition number.
+        X = StandardScaler().fit_transform(X)
+
         return dict(X=X, y=y)


### PR DESCRIPTION
As originaly reported by @david-cortes, covtype contains features of very different scale.
Use a standard scaler to keep a reasonable condition number for the problem.

**TODO:** report results with `sklearn` to check that the optimization is now working.

Fixes #56 